### PR TITLE
입력 개선

### DIFF
--- a/jwak/runtime.py
+++ b/jwak/runtime.py
@@ -8,11 +8,27 @@ class Lang_shung_jwak:
     def __init__(self):
         self.var = [0] * MAX_VARIABLE_SIZE  # list of variable
         self.codeline = []  # list of each codeline
+        self.input_queue = []
 
     @staticmethod
     def print_shungjwak():
         print('\n')
         return
+
+    def append_input_queue(self, value):
+        value = value.split(" ")
+        for v in value:
+            if v.isdigit():
+                self.input_queue.append(int(v))
+            else:
+                for char in v:
+                    self.input_queue.append(ord(char))
+
+    def get_input_queue(self):
+        return self.input_queue.pop(0)
+
+    def get_input_queue_size(self):
+        return len(self.input_queue)
 
     def tokenize_formula(self, code):
         pattern = r"(좍|좌아*악|,+|~+|;+|@+|슝|슈우*웅)"
@@ -173,7 +189,9 @@ class Lang_shung_jwak:
             if code.count("ㅋ") == 0:
                 raise SyntaxError('어떻게 이게 리슝좍이냐!')
             index = code.count("ㅋ") - 1
-            value = int(input())
+            if self.get_input_queue_size() == 0:
+                self.append_input_queue(input())
+            value = self.get_input_queue()
             self.var[index] = value
 
         elif TYPE == 'IF':


### PR DESCRIPTION
## 추가된 사항
 - 한 줄에 여러 입력
 - 입력이 숫자가 아닌 경우 유니코드로 처리

## 예시
```
교주님

슝좌아아아악,좌악

순수따잇ㅋㅋ
순수따잇ㅋㅋㅋ

비비보호막따잇ㅋㅋ
비비따잇ㅋ
비비보호막따잇ㅋㅋㅋ
```

`10 20` 입력 시 `10\n20` 출력

`10 a` 입력 시 `10\n97` 출력

`aa` 입력 시 `97\n97` 출력

`a\nb` 입력 시 `97\n98` 출력
