### PR TITLE
feat(scala): jwak 코드 변환기

### DIFF
--- a/jwak_scala/.gitignore
+++ b/jwak_scala/.gitignore
@@ -1,2 +1,3 @@
-
 .vscode
+jwak-scala.*
+benchmark.md

--- a/jwak_scala/README.md
+++ b/jwak_scala/README.md
@@ -18,16 +18,47 @@ Scala code runner version: 1.5.4
 Scala version (default): 3.6.3
 ```
 
-- 상대 경로로 주어진 파일을 실행합니다.
+### `run`
+
+상대 경로로 주어진 파일을 실행합니다.
 
 ```sh
 # 현재 경로
-$ scala . -- "../example/hello_world.jwak"
+$ scala . -- run "../example/hello_world.jwak"
 Hello, world!
 
 # 프로젝트 루트 경로
-$ scala jwak_scala/ -- "example/hello_world.jwak"
+$ scala jwak_scala/ -- run "example/hello_world.jwak"
 Hello, world!
+```
+
+### `jwak`
+
+주어진 문장을 생성하는 jwak 코드를 생성합니다.
+
+```sh
+$ scala . -- jwak "리슝좍"
+교주님
+슝 좍
+슈웅 좌악, 좌아아아악
+...
+```
+
+### `eval`
+
+jwak 코드를 인자로 받아 실행합니다.
+
+```sh
+$ scala . -- eval "$(scala . -- jwak 리슝좍)"
+리슝좍
+```
+
+### `demo`
+
+모든 예제 코드를 실행합니다.
+
+```sh
+$ scala . -- demo
 ```
 
 ## 기타

--- a/jwak_scala/README.md
+++ b/jwak_scala/README.md
@@ -65,3 +65,33 @@ $ scala . -- demo
 
 - 오류 메시지 및 오류 처리가 제대로 되어 있지 않습니다. 추후 개선 예정입니다.
 - `#` 를 사용한 주석을 지원합니다.
+
+## 패키징
+
+[실행 파일을 패키징](https://scala-cli.virtuslab.org/docs/commands/package)하여 최대 [54배](#벤치마크) 더 빠르게 실행할 수 있습니다.
+
+```sh
+# JVM
+scala --power package . -o jwak-scala.jar -f
+
+# GraalVM
+scala --power package . -o jwak-scala.graal --native-image -f
+
+# Scala Native
+scala --power package . -o jwak-scala.native --native -f
+```
+
+### 벤치마크
+
+```sh
+hyperfine --warmup 5 --export-markdown benchmark.md -N \
+  './jwak-scala.native demo' \
+  './jwak-scala.graal demo' \
+  './jwak-scala.jar demo'
+```
+
+| Command                    |    Mean [ms] | Min [ms] | Max [ms] |     Relative |
+| :------------------------- | -----------: | -------: | -------: | -----------: |
+| `./jwak-scala.native demo` |    8.9 ± 0.4 |      8.2 |     10.9 |         1.00 |
+| `./jwak-scala.graal demo`  |   13.5 ± 0.4 |     12.7 |     15.4 |  1.52 ± 0.08 |
+| `./jwak-scala.jar demo`    | 488.5 ± 11.9 |    473.8 |    510.6 | 54.88 ± 2.56 |

--- a/jwak_scala/main.scala
+++ b/jwak_scala/main.scala
@@ -18,11 +18,13 @@ extension [A](xs: Iterable[A])
       .map((line, idx) => s"${idx.toString.padTo(2, ' ')}: $line")
       .mkString("\n") + "\n"
 
+def codeToExprs(code: String)(using log: JwakLogger): Vector[Expr] =
+  val lines = code.split("\n").toVector
+  log.print(lines.prettyLine)
+  lines.map { 코드.parse(_).toOption.getOrElse(Expr.Noop) }
+
 def run(fileName: String)(using io: JwakIO, log: JwakLogger) =
-  val lines =
-    val lines = fromFile(fileName).getLines.toVector
-    log.print(lines.prettyLine)
-    lines.map { 코드.parse(_).toOption.getOrElse(Expr.Noop) }
+  val lines = codeToExprs(fromFile(fileName).mkString)
 
   log.print(lines.prettyLine)
   val interpreter =

--- a/jwak_scala/project.scala
+++ b/jwak_scala/project.scala
@@ -1,3 +1,4 @@
 //> using dep com.github.j-mie6::parsley:5.0.0-M11
 //> using dep com.github.j-mie6::parsley-debug:5.0.0-M11
+//> using dep com.lihaoyi::mainargs:0.7.6
 //> using toolkit 0.7.0

--- a/jwak_scala/project.scala
+++ b/jwak_scala/project.scala
@@ -1,4 +1,11 @@
-//> using dep com.github.j-mie6::parsley:5.0.0-M11
-//> using dep com.github.j-mie6::parsley-debug:5.0.0-M11
-//> using dep com.lihaoyi::mainargs:0.7.6
+//> using nativeMode release-full
+//> using nativeGc none
+//> using nativeLto thin
+//> using packaging.graalvmArgs -O3 --gc=epsilon
+
+//> using option -feature -deprecation
+
+//> using dep com.github.j-mie6::parsley::5.0.0-M11
+//> using dep com.github.j-mie6::parsley-debug::5.0.0-M11
+//> using dep com.lihaoyi::mainargs::0.7.6
 //> using toolkit 0.7.0

--- a/jwak_scala/runner.scala
+++ b/jwak_scala/runner.scala
@@ -1,0 +1,38 @@
+package jwak.runner
+
+import java.io.File
+import scala.io.Source.fromFile
+
+import parsley.debug.combinator.*
+import parsley.debug.PrintView
+
+import jwak.parser.*
+import jwak.io.*
+import jwak.tojwak.*
+import jwak.interpreter.{given_JwakIO, *}
+import jwak.logger.JwakLogger
+
+extension [A](xs: Iterable[A])
+  def prettyLine =
+    xs.zipWithIndex
+      .map((line, idx) => s"${idx.toString.padTo(2, ' ')}: $line")
+      .mkString("\n") + "\n"
+
+def codeToExprs(code: String)(using log: JwakLogger): Vector[Expr] =
+  val lines = code.split("\n").toVector
+  log.print(lines.prettyLine)
+  lines.map { 코드.parse(_).toOption.getOrElse(Expr.Noop) }
+
+def run(lines: Vector[Expr])(using io: JwakIO, log: JwakLogger): Unit =
+  log.print(lines.prettyLine)
+  val interpreter =
+    MutableInterpreter(lines = lines, maxCommandCount = 1000)(using
+      io = io,
+      log = log,
+    )
+  interpreter.eval()
+  println("\n")
+
+def run(fileName: String)(using io: JwakIO, log: JwakLogger): Unit =
+  val lines = codeToExprs(fromFile(fileName).mkString)
+  run(lines)(using io = io, log = log)

--- a/jwak_scala/toJwak.scala
+++ b/jwak_scala/toJwak.scala
@@ -35,5 +35,3 @@ def toJwak(sentence: String): String =
       .map(getLines)
       .mkString + "비비따잇 ㅋㅋㅋㅋㅋㅋ\n"
   }.mkString
-
-@main def main(sentence: String) = println(toJwak(sentence))

--- a/jwak_scala/toJwak.scala
+++ b/jwak_scala/toJwak.scala
@@ -1,0 +1,39 @@
+package jwak.tojwak
+
+import jwak.parser.{Expr, varAt}
+
+private object JwakConverters:
+  val template =
+    """|교주님
+       |슝 좍
+       |슈웅 좌악, 좌아아아악
+       |슈우웅 슈웅, 슈웅
+       |슈우우웅 슈우웅, 슈웅
+       |슈우우우웅 슈우우웅, 슈웅
+       |""".stripMargin
+
+  extension (inline n: Int)
+    inline def e: String = n match
+      case 1 => "좍"
+      case _ => s"좌${"아" * (n - 2)}악"
+
+  val at6 = varAt(6).n
+
+  def getLines(num: Int, idx: Int) =
+    s"$at6 ${(num + 2).e}; ${2.e}, ${varAt(idx + 1).n}~ $at6\n"
+
+def toJwak(sentence: String): String =
+  import JwakConverters.*
+
+  template + sentence.map { char =>
+    s"$at6\n" + char.toInt.toString
+      .map(_.asDigit)
+      .reverse
+      .iterator
+      .zipWithIndex
+      .filter((num, _) => num != 0)
+      .map(getLines)
+      .mkString + "비비따잇 ㅋㅋㅋㅋㅋㅋ\n"
+  }.mkString
+
+@main def main(sentence: String) = println(toJwak(sentence))

--- a/jwak_scala/toJwak.test.scala
+++ b/jwak_scala/toJwak.test.scala
@@ -1,0 +1,60 @@
+package jwak
+import jwak.interpreter.{MutableInterpreter, given_JwakLogger}
+
+import munit.FunSuite
+import jwak.parser.Expr
+import jwak.io.JwakIO
+
+def evalToJwak(sentence: String) =
+  object StringBuilderIO extends JwakIO:
+    val sb = StringBuilder()
+    def printAscii(v: Int): Unit = sb.append(v.toChar)
+    def printValue(v: Int): Unit = sb.append(v)
+    def readValue(v: Expr.Var): Int = 0
+
+  val code = toJwak(sentence)
+  val exprs = codeToExprs(code)
+
+  val interpreter =
+    MutableInterpreter(lines = exprs)(using io = StringBuilderIO)
+  interpreter.eval()
+  StringBuilderIO.sb.toString
+
+class ToJwakSnapshotTest extends FunSuite:
+  def assertToJwak(input: String) =
+    assertEquals(evalToJwak(input), input)
+
+  test("toJwak produces expected code"):
+    assertToJwak("Hello, World!")
+
+  test("toJwak works with unicode"):
+    assertToJwak("안녕하세요")
+
+  test("toJwak works with special characters"):
+    assertToJwak("!@#$%^&*()_+")
+    assertToJwak("~`")
+    assertToJwak("1234567890")
+
+  test("toJwak works with long message"):
+    val templerun =
+      """|안녕■연아너를처음본순간부터좋아
+         |했어방학전에고백하고싶었는데바보
+         |같이그땐용기가없더라지금은이수많
+         |은사람들앞에서오로지너만사랑한다
+         |고말하고싶어서큰마음먹고용기내어
+         |봐매일매일버스에서너볼때마다두근
+         |댔고동아리랑과활동에서도너만보이
+         |고너생각만나고지난3월부터계속그
+         |랬어니가남자친구랑헤어지고니맘이
+         |아파울때내마음도너무아팠지만내심
+         |좋은맘두있었어이런내맘을어떻게말
+         |할지고민하다가정말인생에서제일크
+         |게용기내어세상에서제일멋지게많은
+         |사람들앞에서너한테고백해주고싶었
+         |어사랑하는■연님내여자가되줄래?
+         |아니나만의태양이되어줄래?난너의
+         |달님이될게내일3시반에너수업마
+         |치고학관앞에서기다리고있을게
+         |너를사랑하는■윤이가""".stripMargin
+    assertToJwak(templerun)
+    assertToJwak("이제 누가 공지해주냐")

--- a/jwak_scala/toJwak.test.scala
+++ b/jwak_scala/toJwak.test.scala
@@ -1,9 +1,11 @@
-package jwak
+package jwak.tojwak
+
 import jwak.interpreter.{MutableInterpreter, given_JwakLogger}
 
 import munit.FunSuite
 import jwak.parser.Expr
 import jwak.io.JwakIO
+import jwak.runner.codeToExprs
 
 def evalToJwak(sentence: String) =
   object StringBuilderIO extends JwakIO:


### PR DESCRIPTION
| `--help` | `jwak` |
| - | - |
| ![image](https://github.com/user-attachments/assets/97f35656-1f13-4458-add9-148194838c75) | ![image](https://github.com/user-attachments/assets/65a2c8b6-5bd6-467d-98ee-a0d4f6740841) |

- scala3 구현체에 도움말을 추가하였습니다.
- scala3 구현체에 주어진 문장을 jwak 코드로 변환하는 `jwak` 명령어를 추가했습니다.
- 네이티브 코드로 빌드하여 실행 속도를 향상시키는 방법을 추가하였습니다.